### PR TITLE
(bug): #97 Update duplicated preset setting not original

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -349,7 +349,7 @@ const App: React.FC<IAppProps> = (props) => {
           <div style={{ marginTop: '8px', fontWeight: 'bold' }}>View Rows:</div>
           <div>
             {activeViewRows?.map((row) => (
-              <div key={String(row['0000'])}>
+              <div key={row._id}>
                 <h6>{row['0000']}</h6>
               </div>
             ))}

--- a/src/components/PluginPresets/index.tsx
+++ b/src/components/PluginPresets/index.tsx
@@ -142,9 +142,7 @@ const PluginPresets: React.FC<IPresetsProps> = ({
       activeTableView: allTables[0].views[0],
     };
 
-    if (type !== PresetHandleAction.duplicate) {
-      onSelectPreset(_id, newPresetActiveState);
-    }
+    onSelectPreset(_id, newPresetActiveState);
   };
 
   // Duplicate a preset


### PR DESCRIPTION
Issue #97 
Bug was due to an initial safeguard set-up. It has been removed since its not needed anymore