### PR TITLE
(Presets): #184 Display presets on mobile

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -43,6 +43,7 @@ import {
   getActiveStateSafeGuard,
   getActiveTableAndActiveView,
   getPluginDataStore,
+  isMobile,
   parsePluginDataToActiveState,
 } from './utils/utils';
 import { SettingsOption } from './utils/types';
@@ -76,6 +77,12 @@ const App: React.FC<IAppProps> = (props) => {
     };
   }, []);
 
+  useEffect(() => {
+    if (isMobile()) {
+      setIsShowState((prevState) => ({ ...prevState, isShowPresets: false }));
+    }
+  }, []);
+
   const initPluginDTableData = async () => {
     if (isDevelopment) {
       // local develop //
@@ -90,10 +97,6 @@ const App: React.FC<IAppProps> = (props) => {
       onDTableChanged();
     });
     resetData();
-  };
-
-  const toggleSettings = () => {
-    setIsShowState((prevState) => ({ ...prevState, isShowSettings: !prevState.isShowSettings }));
   };
 
   let unsubscribeLocalDtableChanged = () => {
@@ -280,7 +283,21 @@ const App: React.FC<IAppProps> = (props) => {
     setAppActiveState(newPresetActiveState);
   };
 
+  const toggleSettings = () => {
+    if (isMobile() && isShowState.isShowPresets) {
+      // Collapse presets if open
+      togglePresets();
+    }
+
+    setIsShowState((prevState) => ({ ...prevState, isShowSettings: !prevState.isShowSettings }));
+  };
+
   const togglePresets = () => {
+    if (isMobile() && isShowState.isShowSettings) {
+      // Collapse settings if open
+      toggleSettings();
+    }
+
     setIsShowState((prevState) => ({ ...prevState, isShowPresets: !prevState.isShowPresets }));
   };
 
@@ -463,17 +480,16 @@ const App: React.FC<IAppProps> = (props) => {
               </div>
             </button>
           </div>
-          <div>
-            <PluginSettings
-              isShowSettings={isShowSettings}
-              allTables={allTables}
-              appActiveState={appActiveState}
-              activeTableViews={activeTableViews}
-              pluginPresets={pluginPresets}
-              onTableOrViewChange={onTableOrViewChange}
-              onToggleSettings={toggleSettings}
-            />
-          </div>
+
+          <PluginSettings
+            isShowSettings={isShowSettings}
+            allTables={allTables}
+            appActiveState={appActiveState}
+            activeTableViews={activeTableViews}
+            pluginPresets={pluginPresets}
+            onTableOrViewChange={onTableOrViewChange}
+            onToggleSettings={toggleSettings}
+          />
         </div>
       </div>
     </ResizableWrapper>

--- a/src/styles/Modal.module.scss
+++ b/src/styles/Modal.module.scss
@@ -123,17 +123,25 @@
       justify-content: space-between;
 
       @include mobile {
-        font-size: 10px;
+        font-size: 12px;
       }
 
       &_icons {
         justify-self: center;
         opacity: 0;
         color: colorContrast($preset-bgColor);
+        
+        @include mobile {
+          opacity: 1;
+        }
       }
       &_settings {
         opacity: 0;
         color: colorContrast($preset-bgColor);
+
+        @include mobile {
+          opacity: 1;
+        }
       }
 
       &:hover {
@@ -154,7 +162,7 @@
       width: 25%;
 
       @include mobile {
-        width: 15%;
+        width: 20%;
       }
     }
 

--- a/src/styles/PluginSettings.module.scss
+++ b/src/styles/PluginSettings.module.scss
@@ -1,14 +1,12 @@
 @import './abstracts/_media.scss';
 @import './constants.scss';
 // STYLE FOR PLUGIN SETTINGS COMPONENT
-
 .settings,
 .settings_hide {
   position: fixed;
   right: 0;
   height: 100%;
   width: 25%;
-  max-width: 400px;
   transition: 0.3s width ease-in-out;
   border-left: 1px solid $borderColor;
 
@@ -23,8 +21,13 @@
   }
 
   @include mobile {
-    border-radius: 0px 10px 0 0;
+    width: 60%;
+    max-width: none;
+  }
+
+  @include mini {
     width: 100%;
+    max-width: none;
   }
 
   &_dropdowns {

--- a/src/styles/Presets.module.scss
+++ b/src/styles/Presets.module.scss
@@ -13,8 +13,11 @@
   transition: 0.3s width ease-in-out;
 
   @include tablet {
-    position: fixed;
-    display: none;
+    width: 70%;
+  }
+
+  @include mini {
+    width: 90%;
   }
 
   &_icon {
@@ -24,7 +27,6 @@
     border-radius: 10%;
     margin-right: 8px;
   }
-
   &_collapsed {
     width: 0;
     margin-right: -1px;
@@ -32,13 +34,13 @@
     .presets_collapse_btn {
       display: none;
     }
+
+    @include tablet {
+    }
   }
 
   &_logo {
     padding-left: 24px;
-    @include mobile {
-      transform: scale(0.7);
-    }
   }
 
   &_name {
@@ -49,8 +51,7 @@
     margin-bottom: 0;
 
     @include mobile {
-      font-size: 11px;
-      margin-left: -5px;
+      font-size: 12px;
     }
   }
 
@@ -72,6 +73,10 @@
     opacity: 0;
     transition: 0.2s opacity ease-in-out;
     cursor: pointer;
+
+    @include tablet {
+      opacity: 1;
+    }
   }
 
   &_uncollapse_btn2,
@@ -107,6 +112,18 @@
     &:hover {
       background-color: $add-btn-hover;
     }
+
+    .dtable-font {
+      @include mobile {
+        font-size: 14px;
+      }
+    }
+
+    p {
+      @include mobile {
+        font-size: 12px;
+      }
+    }
   }
 
   &_input {
@@ -129,6 +146,10 @@
       font-family: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans,
         Ubuntu, Cantarell, 'Helvetica Neue', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', sans-serif;
+
+      @include mobile {
+        font-size: 12px;
+      }
     }
 
     button {

--- a/src/styles/abstracts/_media.scss
+++ b/src/styles/abstracts/_media.scss
@@ -23,3 +23,9 @@
     @content;
   }
 }
+
+@mixin mini{
+  @media screen and (max-width: 450px) {
+    @content;
+  }
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -383,3 +383,7 @@ export const createDefaultPresetSettings = (allTables: TableArray) => {
 export const findPresetName = (presets: PresetsArray, presetId: string) => {
   return presets.find((preset) => preset._id === presetId)?.name;
 };
+
+export const isMobile = () => {
+  return (window.innerWidth <= 800)
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -385,5 +385,5 @@ export const findPresetName = (presets: PresetsArray, presetId: string) => {
 };
 
 export const isMobile = () => {
-  return (window.innerWidth <= 800)
-}
+  return (window.innerWidth <= 800);
+};


### PR DESCRIPTION
Issue #184 

- Close each overlay (settings and presets) at appropriate times
- Make icons always visible since there is no hover on mobile

https://github.com/seatable/seatable-plugin-template-base/assets/69858244/937ed502-2314-4b68-b131-95a2de7afd5d

